### PR TITLE
fix type for $value in DocBlock

### DIFF
--- a/NumberFormatter/NumberFormatter.php
+++ b/NumberFormatter/NumberFormatter.php
@@ -639,7 +639,7 @@ class NumberFormatter
      * Not supported. Set a text attribute.
      *
      * @param int $attr  An attribute specifier, one of the text attribute constants
-     * @param int $value The attribute value
+     * @param string $value The attribute value
      *
      * @return bool true on success or false on failure
      *


### PR DESCRIPTION
`$value` is supposed to be a string, not an int, according to [`NumberFormatter::setTextAttribute()` documentation](https://secure.php.net/manual/en/numberformatter.settextattribute.php)