### PR TITLE
Backport some bugfixes of 3.x and 4.x to avoid infinite loops

### DIFF
--- a/Locale.php
+++ b/Locale.php
@@ -85,7 +85,9 @@ final class Locale extends \Locale
 
             array_pop($localeSubTags);
 
-            return locale_compose($localeSubTags);
+            $fallback = locale_compose($localeSubTags);
+
+            return false !== $fallback ? $fallback : null;
         }
 
         if (false !== $pos = strrpos($locale, '_')) {
@@ -105,6 +107,8 @@ final class Locale extends \Locale
         if (\strlen($locale) < 4) {
             return self::$defaultFallback;
         }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
Fix infinite loop for some PHP versions the same as the as the latest 3.x and 4.x versions of this package
Also return null if no condition is true

Mautic 2.x & 3.x is currently using these repositories and would be good to no longer use forked versions