### PR TITLE
Fix LanguageDataGenerator: update code alpha 3 for DZ to DZA instance of DZO

### DIFF
--- a/Data/Generator/LanguageDataGenerator.php
+++ b/Data/Generator/LanguageDataGenerator.php
@@ -39,7 +39,7 @@ class LanguageDataGenerator extends AbstractDataGenerator
         'cs' => 'ces',
         'cy' => 'cym',
         'de' => 'deu',
-        'dz' => 'dzo',
+        'dz' => 'dza',
         'el' => 'ell',
         'et' => 'est',
         'eu' => 'eus',


### PR DESCRIPTION
# QUOI

Le code Iso  Alpha 2 de l'Algérie est DZ, et son code Alpha 3 est DZA
https://www.iso.org/obp/ui/fr/#iso:code:3166:DZ

Seulement, la librairie retourne DZO.  (ligne 42 :sweat_smile:)
https://github.com/symfony/intl/blob/6.2/Data/Generator/LanguageDataGenerator.php

# COMMENT

Mise à jour du tableau d'association du fichier ``Data/Generator/LanguageDataGenerator.php``

```
"dz" => "dza"
```